### PR TITLE
fix: update README to correct Browser Platform Publisher link

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 
 # Browser Market Submit
 
-A NodeJS library from [Plasmo](https://www.plasmo.com/) to submit browser extensions to multiple stores. It is made to be used in the [Browser Platform Publisher](https://bpp.browser.market) action.
+A NodeJS library from [Plasmo](https://www.plasmo.com/) to submit browser extensions to multiple stores. It is made to be used in the [Browser Platform Publisher](https://github.com/marketplace/actions/browser-platform-publisher) action.
 
 Supported stores:
 


### PR DESCRIPTION
This PR fixes a broken link (`https://bpp.browser.market`) to the correct one (`https://github.com/marketplace/actions/browser-platform-publisher`).